### PR TITLE
add JSON schema send metrics

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -14,8 +14,8 @@ import (
 func main() {
 	agent := app.NewAgent()
 	ctx := context.Background()
+	metric := &metric.Metrics{}
 
-	metric := metric.NewMetrics()
 	go agent.Poll(ctx, metric)
 	go agent.Report(ctx, metric)
 

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/go-chi/chi v1.5.5
 	github.com/stretchr/testify v1.9.0
+	go.uber.org/zap v1.27.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/app/agent_test.go
+++ b/internal/app/agent_test.go
@@ -27,7 +27,7 @@ func Test_agent_Poll(t *testing.T) {
 		ReportInterval: 10 * time.Second,
 		ServerAddress:  "localhost:8080",
 	}
-	metrics := metric.NewMetrics()
+	metrics := &metric.Metrics{}
 	type args struct {
 		ctx     context.Context
 		metrics *metric.Metrics

--- a/internal/config/serverconfig.go
+++ b/internal/config/serverconfig.go
@@ -11,12 +11,15 @@ type (
 	ServerConfig struct {
 		// ListenAddress - адрес сервера сбора метрик
 		ListenAddress string `env:"ADDRESS"`
+		// LogLevel - уровень логирования, по умолчанию info
+		LogLevel string
 	}
 )
 
 func NewServerConfig() ServerConfig {
 	cfg := ServerConfig{
 		ListenAddress: "localhost:8080",
+		LogLevel:      "info",
 	}
 
 	flag.Usage = func() {

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -47,7 +47,7 @@ func (h metricHandlers) Get(w http.ResponseWriter, r *http.Request) {
 
 	value, err := h.service.Get(name, kind)
 	if err != nil {
-		responseWithCode(w, http.StatusBadRequest)
+		responseWithCode(w, http.StatusNotFound)
 		return
 	}
 

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -7,53 +7,67 @@ import (
 
 	"github.com/go-chi/chi"
 
+	"github.com/a-x-a/go-metric/internal/models/metric"
 	"github.com/a-x-a/go-metric/internal/storage"
 )
 
 type (
 	metricService interface {
 		Push(name, kind, value string) error
+		PushCounter(name string, value metric.Counter) (metric.Counter, error)
+		PushGauge(name string, value metric.Gauge) (metric.Gauge, error)
 		Get(name, kind string) (string, error)
 		GetAll() []storage.Record
 	}
+	metricHandlers struct {
+		service metricService
+	}
 )
-type metricHandlers struct {
-	service metricService
-}
 
 func newMetricHandlers(s metricService) metricHandlers {
 	return metricHandlers{s}
 }
 
 func (h metricHandlers) List(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+
 	records := h.service.GetAll()
 	for _, v := range records {
 		io.WriteString(w, fmt.Sprintf("%s\t%s\n", v.GetName(), v.GetValue().String()))
 	}
-	ok(w)
+
+	responseWithCode(w, http.StatusOK)
 }
 
 func (h metricHandlers) Get(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+
 	kind := chi.URLParam(r, "kind")
 	name := chi.URLParam(r, "name")
+
 	value, err := h.service.Get(name, kind)
 	if err != nil {
-		notFound(w)
+		responseWithCode(w, http.StatusNotFound)
 		return
 	}
 
 	w.Write([]byte(value))
-	ok(w)
+
+	responseWithCode(w, http.StatusOK)
 }
 
 func (h metricHandlers) Update(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+
 	kind := chi.URLParam(r, "kind")
 	name := chi.URLParam(r, "name")
 	value := chi.URLParam(r, "value")
+
 	err := h.service.Push(name, kind, value)
 	if err != nil {
-		badRequest(w)
+		responseWithCode(w, http.StatusNotFound)
 		return
 	}
-	ok(w)
+
+	responseWithCode(w, http.StatusOK)
 }

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -47,7 +47,7 @@ func (h metricHandlers) Get(w http.ResponseWriter, r *http.Request) {
 
 	value, err := h.service.Get(name, kind)
 	if err != nil {
-		responseWithCode(w, http.StatusNotFound)
+		responseWithCode(w, http.StatusBadRequest)
 		return
 	}
 
@@ -65,7 +65,7 @@ func (h metricHandlers) Update(w http.ResponseWriter, r *http.Request) {
 
 	err := h.service.Push(name, kind, value)
 	if err != nil {
-		responseWithCode(w, http.StatusNotFound)
+		responseWithCode(w, http.StatusBadRequest)
 		return
 	}
 

--- a/internal/handler/handlersJSON.go
+++ b/internal/handler/handlersJSON.go
@@ -1,0 +1,101 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/a-x-a/go-metric/internal/models/metric"
+	"github.com/a-x-a/go-metric/internal/schema"
+)
+
+func (h metricHandlers) UpdateJSON(w http.ResponseWriter, r *http.Request) {
+	data := &schema.RequestMetric{}
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		responseWithError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	switch data.MType {
+	case "counter":
+		val, err := h.service.PushCounter(data.ID, metric.Counter(*data.Delta))
+		if err != nil {
+			responseWithError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		newDelta := int64(val)
+		data.Delta = &newDelta
+
+	case "gauge":
+		val, err := h.service.PushGauge(data.ID, metric.Gauge(*data.Value))
+		if err != nil {
+			responseWithError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		newValue := float64(val)
+		data.Value = &newValue
+
+	default:
+		responseWithCode(w, http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		responseWithError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	responseWithCode(w, http.StatusOK)
+}
+
+func (h metricHandlers) GetJSON(w http.ResponseWriter, r *http.Request) {
+	data := &schema.RequestMetric{}
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		responseWithError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	value, err := h.service.Get(data.ID, data.MType)
+	if err != nil {
+		responseWithCode(w, http.StatusNotFound)
+		return
+	}
+
+	switch data.MType {
+	case "counter":
+		val, err := metric.ToCounter(value)
+		if err != nil {
+			responseWithError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		newDelta := int64(val)
+		data.Delta = &newDelta
+
+	case "gauge":
+		val, err := metric.ToGauge(value)
+		if err != nil {
+			responseWithError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		newValue := float64(val)
+		data.Value = &newValue
+
+	default:
+		responseWithCode(w, http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		responseWithError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	responseWithCode(w, http.StatusOK)
+}

--- a/internal/handler/handlersJSON.go
+++ b/internal/handler/handlersJSON.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/a-x-a/go-metric/internal/models/metric"
@@ -36,6 +37,7 @@ func (h metricHandlers) UpdateJSON(w http.ResponseWriter, r *http.Request) {
 		newValue := float64(val)
 		data.Value = &newValue
 
+		fmt.Println("data:=", data.ID, data.MType, *data.Value)
 	default:
 		responseWithCode(w, http.StatusBadRequest)
 		return

--- a/internal/handler/handlers_test.go
+++ b/internal/handler/handlers_test.go
@@ -40,6 +40,22 @@ func (s service) Push(name, kind, value string) error {
 	return nil
 }
 
+func (s service) PushCounter(name string, value metric.Counter) (metric.Counter, error) {
+	if name == "" {
+		return 0, storage.ErrInvalidName
+	}
+
+	return value, nil
+}
+
+func (s service) PushGauge(name string, value metric.Gauge) (metric.Gauge, error) {
+	if name == "" {
+		return 0, storage.ErrInvalidName
+	}
+
+	return value, nil
+}
+
 func (s service) Get(name, kind string) (string, error) {
 	_, err := metric.GetKind(kind)
 	if err != nil {

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -18,7 +18,7 @@ func Router(s metricService) http.Handler {
 	r.Get("/value/{kind}/{name}", metricHendlers.Get)
 	r.Post("/update/{kind}/{name}/{value}", metricHendlers.Update)
 
-	r.Get("/value/", metricHendlers.GetJSON)
+	r.Post("/value/", metricHendlers.GetJSON)
 	r.Post("/update/", metricHendlers.UpdateJSON)
 
 	return r

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi"
@@ -17,25 +18,20 @@ func Router(s metricService) http.Handler {
 	r.Get("/value/{kind}/{name}", metricHendlers.Get)
 	r.Post("/update/{kind}/{name}/{value}", metricHendlers.Update)
 
+	r.Get("/value/", metricHendlers.GetJSON)
+	r.Post("/update/", metricHendlers.UpdateJSON)
+
 	return r
 }
 
-func ok(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
-	w.WriteHeader(http.StatusOK)
+func responseWithError(w http.ResponseWriter, code int, err error) {
+	resp := fmt.Sprintf("%d: %s", code, err.Error())
+	logger.Log.Error(resp)
+	http.Error(w, resp, code)
 }
 
-func notFound(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
-	w.WriteHeader(http.StatusNotFound)
+func responseWithCode(w http.ResponseWriter, code int) {
+	resp := fmt.Sprintf("%d: %s", code, http.StatusText(code))
+	logger.Log.Debug(resp)
+	w.WriteHeader(code)
 }
-
-func badRequest(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
-	w.WriteHeader(http.StatusBadRequest)
-}
-
-// func internalServerError(w http.ResponseWriter) {
-// 	w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
-// 	w.WriteHeader(http.StatusInternalServerError)
-// }

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -4,12 +4,15 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi"
+
+	"github.com/a-x-a/go-metric/internal/logger"
 )
 
 func Router(s metricService) http.Handler {
 	metricHendlers := newMetricHandlers(s)
 	r := chi.NewRouter()
-	// r.Use(logging.RequestsLogger)
+	r.Use(logger.WithLogger)
+
 	r.Get("/", metricHendlers.List)
 	r.Get("/value/{kind}/{name}", metricHendlers.Get)
 	r.Post("/update/{kind}/{name}/{value}", metricHendlers.Update)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,86 @@
+package logger
+
+import (
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Log будет доступен всему коду как синглтон.
+// По умолчанию установлен no-op-логер, который не выводит никаких сообщений.
+var Log *zap.Logger = zap.NewNop()
+
+// Initialize инициализирует синглтон логера с необходимым уровнем логирования.
+func Initialize(level string) error {
+	// преобразуем текстовый уровень логирования в zap.AtomicLevel
+	lvl, err := zap.ParseAtomicLevel(level)
+	if err != nil {
+		return err
+	}
+	// создаём новую конфигурацию логера
+	cfg := zap.NewProductionConfig()
+	// устанавливаем уровень
+	cfg.Level = lvl
+	// создаём логер на основе конфигурации
+	zl, err := cfg.Build()
+	if err != nil {
+		return err
+	}
+	// устанавливаем синглтон
+	Log = zl
+	return nil
+}
+
+func WithLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		responseData := &responseData{
+			status: 0,
+			size:   0,
+		}
+		lw := loggingResponseWriter{
+			ResponseWriter: w, // встраиваем оригинальный http.ResponseWriter
+			responseData:   responseData,
+		}
+		start := time.Now()
+
+		next.ServeHTTP(&lw, r)
+
+		duration := time.Since(start)
+
+		Log.Info("",
+			zap.String("uri", r.RequestURI),
+			zap.String("method", r.Method),
+			zap.Duration("duration", duration),
+			zap.Int("status", responseData.status),
+			zap.Int("size", responseData.size),
+		)
+	})
+}
+
+type (
+	// берём структуру для хранения сведений об ответе
+	responseData struct {
+		status int
+		size   int
+	}
+
+	// добавляем реализацию http.ResponseWriter
+	loggingResponseWriter struct {
+		http.ResponseWriter // встраиваем оригинальный http.ResponseWriter
+		responseData        *responseData
+	}
+)
+
+func (r *loggingResponseWriter) Write(b []byte) (int, error) {
+	// записываем ответ, используя оригинальный http.ResponseWriter
+	size, err := r.ResponseWriter.Write(b)
+	r.responseData.size += size // захватываем размер
+	return size, err
+}
+
+func (r *loggingResponseWriter) WriteHeader(statusCode int) {
+	// записываем код статуса, используя оригинальный http.ResponseWriter
+	r.ResponseWriter.WriteHeader(statusCode)
+	r.responseData.status = statusCode // захватываем код статуса
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -13,21 +13,21 @@ var Log *zap.Logger = zap.NewNop()
 
 // Initialize инициализирует синглтон логера с необходимым уровнем логирования.
 func Initialize(level string) error {
-	// преобразуем текстовый уровень логирования в zap.AtomicLevel
+	// преобразуем текстовый уровень логирования в zap.AtomicLevel.
 	lvl, err := zap.ParseAtomicLevel(level)
 	if err != nil {
 		return err
 	}
-	// создаём новую конфигурацию логера
+	// создаём новую конфигурацию логера.
 	cfg := zap.NewProductionConfig()
-	// устанавливаем уровень
+	// устанавливаем уровень.
 	cfg.Level = lvl
-	// создаём логер на основе конфигурации
+	// создаём логер на основе конфигурации.
 	zl, err := cfg.Build()
 	if err != nil {
 		return err
 	}
-	// устанавливаем синглтон
+	// устанавливаем синглтон.
 	Log = zl
 	return nil
 }
@@ -39,7 +39,7 @@ func WithLogger(next http.Handler) http.Handler {
 			size:   0,
 		}
 		lw := loggingResponseWriter{
-			ResponseWriter: w, // встраиваем оригинальный http.ResponseWriter
+			ResponseWriter: w,
 			responseData:   responseData,
 		}
 		start := time.Now()
@@ -59,28 +59,28 @@ func WithLogger(next http.Handler) http.Handler {
 }
 
 type (
-	// берём структуру для хранения сведений об ответе
+	// берём структуру для хранения сведений об ответе.
 	responseData struct {
 		status int
 		size   int
 	}
 
-	// добавляем реализацию http.ResponseWriter
+	// добавляем реализацию http.ResponseWriter.
 	loggingResponseWriter struct {
-		http.ResponseWriter // встраиваем оригинальный http.ResponseWriter
+		http.ResponseWriter // встраиваем оригинальный http.ResponseWriter.
 		responseData        *responseData
 	}
 )
 
 func (r *loggingResponseWriter) Write(b []byte) (int, error) {
-	// записываем ответ, используя оригинальный http.ResponseWriter
+	// записываем ответ, используя оригинальный http.ResponseWriter.
 	size, err := r.ResponseWriter.Write(b)
-	r.responseData.size += size // захватываем размер
+	r.responseData.size += size // захватываем размер.
 	return size, err
 }
 
 func (r *loggingResponseWriter) WriteHeader(statusCode int) {
-	// записываем код статуса, используя оригинальный http.ResponseWriter
+	// записываем код статуса, используя оригинальный http.ResponseWriter.
 	r.ResponseWriter.WriteHeader(statusCode)
-	r.responseData.status = statusCode // захватываем код статуса
+	r.responseData.status = statusCode // захватываем код статуса.
 }

--- a/internal/models/metric/counter.go
+++ b/internal/models/metric/counter.go
@@ -23,3 +23,12 @@ func (c Counter) IsCounter() bool {
 func (c Counter) IsGauge() bool {
 	return false
 }
+
+func ToCounter(value string) (Counter, error) {
+	val, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return Counter(val), nil
+}

--- a/internal/models/metric/counter_test.go
+++ b/internal/models/metric/counter_test.go
@@ -94,3 +94,57 @@ func TestCounter_IsGauge(t *testing.T) {
 		})
 	}
 }
+func TestToCounter(t *testing.T) {
+	tt := []struct {
+		name     string
+		value    string
+		valid    bool
+		expected Counter
+	}{
+		{
+			name:     "positive integer",
+			value:    "13",
+			valid:    true,
+			expected: 13,
+		},
+		{
+			name:     "zero integer",
+			value:    "0",
+			valid:    true,
+			expected: 0,
+		},
+		{
+			name:     "negative integer",
+			value:    "-13",
+			valid:    true,
+			expected: -13,
+		},
+		{
+			name:  "positive float",
+			value: "2345678.000000",
+			valid: false,
+		},
+		{
+			name:  "zero float",
+			value: "0.000000",
+			valid: false,
+		},
+		{
+			name:  "negative float",
+			value: "-2345678.000000",
+			valid: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			metric, err := ToCounter(tc.value)
+			if tc.valid {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, metric)
+			} else {
+				assert.NotNil(t, err)
+			}
+		})
+	}
+}

--- a/internal/models/metric/gauge.go
+++ b/internal/models/metric/gauge.go
@@ -26,3 +26,12 @@ func (g Gauge) IsCounter() bool {
 func (g Gauge) IsGauge() bool {
 	return true
 }
+
+func ToGauge(value string) (Gauge, error) {
+	val, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return Gauge(val), nil
+}

--- a/internal/models/metric/gauge_test.go
+++ b/internal/models/metric/gauge_test.go
@@ -99,3 +99,77 @@ func TestGauge_IsGauge(t *testing.T) {
 		})
 	}
 }
+
+func TestToGauge(t *testing.T) {
+	tt := []struct {
+		name     string
+		value    string
+		valid    bool
+		expected Gauge
+	}{
+		{
+			name:     "positive integer",
+			value:    "13",
+			valid:    true,
+			expected: 13.0,
+		},
+		{
+			name:     "zero integer",
+			value:    "0",
+			valid:    true,
+			expected: 0.0,
+		},
+		{
+			name:     "negative integer",
+			value:    "-13",
+			valid:    true,
+			expected: -13.0,
+		},
+		{
+			name:     "positive float",
+			value:    "2345678.1234000",
+			valid:    true,
+			expected: 2345678.1234,
+		},
+		{
+			name:     "zero float",
+			value:    "0.000000",
+			valid:    true,
+			expected: 0.0,
+		},
+		{
+			name:     "negative float",
+			value:    "-2345678.1234000",
+			valid:    true,
+			expected: -2345678.1234,
+		},
+		{
+			name:     "small positive float",
+			value:    "0.654321",
+			valid:    true,
+			expected: 0.654321,
+		},
+		{
+			name:  "meaningless value",
+			value: "...",
+			valid: false,
+		},
+		{
+			name:  "malformed value",
+			value: "0.12(",
+			valid: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			metric, err := ToGauge(tc.value)
+			if tc.valid {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, metric)
+			} else {
+				assert.NotNil(t, err)
+			}
+		})
+	}
+}

--- a/internal/models/metric/metric.go
+++ b/internal/models/metric/metric.go
@@ -31,10 +31,6 @@ var (
 	ErrorMetricNotFound = errors.New("metrics: метрика не найдена")
 )
 
-func NewMetrics() *Metrics {
-	return &Metrics{}
-}
-
 func (m *Metrics) Poll() {
 	m.PollCount += 1
 	m.RandomValue = Gauge(rand.Float64())

--- a/internal/models/metric/metric.go
+++ b/internal/models/metric/metric.go
@@ -32,12 +32,11 @@ var (
 )
 
 func NewMetrics() *Metrics {
-	return &Metrics{
-		RandomValue: Gauge(rand.Float64()),
-	}
+	return &Metrics{}
 }
 
 func (m *Metrics) Poll() {
 	m.PollCount += 1
+	m.RandomValue = Gauge(rand.Float64())
 	m.Memory.Poll()
 }

--- a/internal/models/metric/metric_test.go
+++ b/internal/models/metric/metric_test.go
@@ -4,26 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestNewMetrics(t *testing.T) {
-	tests := []struct {
-		name string
-	}{
-		{
-			name: "new metrics create",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.NotEmpty(t, NewMetrics())
-		})
-	}
-}
-
 func TestMetrics_Poll(t *testing.T) {
-	metric := NewMetrics()
+	metric := &Metrics{}
 	tests := []struct {
 		name  string
 		m     *Metrics

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -21,6 +21,7 @@ func NewUpdateRequestMetricCounter(name string, value metric.Counter) RequestMet
 
 func NewUpdateRequestMetricGauge(name string, value metric.Gauge) RequestMetric {
 	val := float64(value)
+
 	return RequestMetric{
 		ID:    name,
 		MType: value.Kind(),

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1,0 +1,43 @@
+package schema
+
+import "github.com/a-x-a/go-metric/internal/models/metric"
+
+type RequestMetric struct {
+	ID    string   `json:"id"`              // имя метрики
+	MType string   `json:"type"`            // параметр, принимающий значение gauge или counter
+	Delta *int64   `json:"delta,omitempty"` // значение метрики в случае передачи counter
+	Value *float64 `json:"value,omitempty"` // значение метрики в случае передачи gauge
+}
+
+func NewUpdateRequestMetricCounter(name string, value metric.Counter) RequestMetric {
+	val := int64(value)
+
+	return RequestMetric{
+		ID:    name,
+		MType: value.Kind(),
+		Delta: &val,
+	}
+}
+
+func NewUpdateRequestMetricGauge(name string, value metric.Gauge) RequestMetric {
+	val := float64(value)
+	return RequestMetric{
+		ID:    name,
+		MType: value.Kind(),
+		Value: &val,
+	}
+}
+
+func NewGetRequestMetricCounter(name string) RequestMetric {
+	return RequestMetric{
+		ID:    name,
+		MType: "counter",
+	}
+}
+
+func NewGetRequestMetricGauge(name string) RequestMetric {
+	return RequestMetric{
+		ID:    name,
+		MType: "gauge",
+	}
+}

--- a/internal/service/metricservice/metricservice.go
+++ b/internal/service/metricservice/metricservice.go
@@ -75,7 +75,12 @@ func (s *metricService) PushGauge(name string, value metric.Gauge) (metric.Gauge
 
 	record.SetValue(value)
 
-	return value, s.storage.Push(name, record)
+	err = s.storage.Push(name, record)
+	if err != nil {
+		return 0, err
+	}
+
+	return value, nil
 }
 
 func (s metricService) Get(name, kind string) (string, error) {


### PR DESCRIPTION
API сервера, позволяет принимать метрики в формате JSON.
Для обмена с сервером используется следующая структура:
```go
 type Metrics struct {
     ID    string   `json:"id"`              // имя метрики
     MType string   `json:"type"`            // параметр, принимающий значение gauge или counter
     Delta *int64   `json:"delta,omitempty"` // значение метрики в случае передачи counter
     Value *float64 `json:"value,omitempty"` // значение метрики в случае передачи gauge
  } 
```
Агент переведен на новый API.